### PR TITLE
Update UIColor+BFKit.swift

### DIFF
--- a/Source/Extensions/UIKit/UIColor+BFKit.swift
+++ b/Source/Extensions/UIKit/UIColor+BFKit.swift
@@ -443,9 +443,9 @@ public extension UIColor {
      - returns: Returns the UIColor instance
      */
     public static func randomColor() -> UIColor {
-        let r: Int = Int(arc4random()) % 255
-        let g: Int = Int(arc4random()) % 255
-        let b: Int = Int(arc4random()) % 255
+        let r: UInt32 = arc4random_uniform(255)
+        let g: UInt32 = arc4random_uniform(255)
+        let b: UInt32 = arc4random_uniform(255)
         
         return UIColor(red: CGFloat(r) / 255.0, green: CGFloat(g) / 255.0, blue: CGFloat(b) / 255.0, alpha: 1.0)
     }


### PR DESCRIPTION
Crash on Simulator EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0) fix
