### PR TITLE
Simplify colors usage

### DIFF
--- a/Source/Extensions/UIKit/UIColor+BFKit.swift
+++ b/Source/Extensions/UIKit/UIColor+BFKit.swift
@@ -39,7 +39,7 @@ import UIKit
 
  - returns: Returns the created UIColor
  */
-public func RGBA(r: Int, g: Int, b: Int, a: Float) -> UIColor {
+public func RGBA(r: Int, _ g: Int, _ b: Int, _ a: Float) -> UIColor {
     return UIColor(red: CGFloat(r)/255.0, green: CGFloat(g)/255.0, blue: CGFloat(b)/255.0, alpha: CGFloat(a))
 }
 
@@ -52,7 +52,7 @@ public func RGBA(r: Int, g: Int, b: Int, a: Float) -> UIColor {
 
  - returns: Returns the created UIColor
  */
-public func RGB(r: Int, g: Int, b: Int) -> UIColor {
+public func RGB(r: Int, _ g: Int, _ b: Int) -> UIColor {
     return UIColor(red: CGFloat(r)/255.0, green: CGFloat(g)/255.0, blue: CGFloat(b)/255.0, alpha: 1.0)
 }
 


### PR DESCRIPTION
Instead of `RGB(250, g: 250, b: 250)` just `RGB(250, 250, 250)`
