### PR TITLE
Cocoapod Fix : Typo `Source` → `Sources`

### DIFF
--- a/BFKit-Swift.podspec
+++ b/BFKit-Swift.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
                           :git => "https://github.com/FabrizioBrancati/BFKit-Swift.git",
                           :tag => s.version
                        }
-  s.source_files     = "Source/**/*.{swift}"
-  s.resources        = "Source/Languages/**"
+  s.source_files     = "Sources/**/*.{swift}"
+  s.resources        = "Sources/Languages/**"
   s.requires_arc     = true
 end


### PR DESCRIPTION
Hi, thanks for the nice work. 
I noticed the library wasn't building correctly with cocoapods so after looking around I found out this small typo 😉 .
