### PR TITLE
improve compilation time in UIImageExtension:blur(...) method

### DIFF
--- a/Sources/BFKit/Apple/UIKit/UIImageExtension.swift
+++ b/Sources/BFKit/Apple/UIKit/UIImageExtension.swift
@@ -816,7 +816,8 @@ public extension UIImage {
                 
                 if hasBlur {
                     var inputRadius = blurRadius * UIImage.screenScale()
-                    inputRadius = inputRadius * 3.0 * CGFloat(sqrt(2 * Double.pi)) / 4 + 0.5
+                    let sqrt2PI: CGFloat = CGFloat(sqrt(2 * Double.pi))
+                    inputRadius = inputRadius * 3.0 * sqrt2PI / 4 + 0.5
                     var radius = UInt32(floor(inputRadius))
                     if radius % 2 != 1 {
                         radius += 1


### PR DESCRIPTION
Before:

> 1920.52ms	...UIImageExtension.swift:788:21	public func blur(radius blurRadius: CGFloat, saturation: CGFloat = default, tintColor: UIColor? = default, maskImage: UIImage? = default) -> UIImage

After:

>114.58ms	...UIImageExtension.swift:788:21	public func blur(radius blurRadius: CGFloat, saturation: CGFloat = default, tintColor: UIColor? = default, maskImage: UIImage? = default) -> UIImage
